### PR TITLE
change filename separator to '_' from '-' so Sprockets works.

### DIFF
--- a/lib/fontcustom/scripts/generate.py
+++ b/lib/fontcustom/scripts/generate.py
@@ -88,7 +88,7 @@ if args.nohash:
 	fontfile = outdir + '/' + args.name
 else:
 	hashStr = m.hexdigest()
-	fontfile = outdir + '/' + args.name + '-' + hashStr
+	fontfile = outdir + '/' + args.name + '_' + hashStr
 
 f.fontname = args.name
 f.familyname = args.name


### PR DESCRIPTION
When using Sprockets, the current filename format causes Not Found errors.
Switching to '_' as a separator fixes this.
